### PR TITLE
Fix for Ranger 2.4 HMSA startup issue

### DIFF
--- a/agents-audit/pom.xml
+++ b/agents-audit/pom.xml
@@ -42,11 +42,22 @@
             <artifactId>commons-lang</artifactId>
             <version>${commons.lang.version}</version>
         </dependency>
+<!--        This dependency was coming from Hadoop but it has been replaced in Hadoop 3.3.6.-->
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <version>${jersey-bundle.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
+                <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
                  <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>

--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>jersey-bundle</artifactId>
             <version>${jersey-bundle.version}</version>
         </dependency>
+<!--        This dependency was coming from Hadoop but it has been replaced in Hadoop 3.3.6.-->
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <version>${jersey-bundle.version}</version>
+        </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
@@ -87,6 +93,11 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
+                <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>net.minidev</groupId>
                     <artifactId>json-smart</artifactId>

--- a/agents-cred/pom.xml
+++ b/agents-cred/pom.xml
@@ -37,6 +37,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>net.minidev</groupId>
                     <artifactId>json-smart</artifactId>
                 </exclusion>
@@ -65,6 +70,12 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+<!--        This dependency was coming from Hadoop but the package has been replaced in Hadoop 3.3.6.-->
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <version>${jersey-bundle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/credentialbuilder/pom.xml
+++ b/credentialbuilder/pom.xml
@@ -75,6 +75,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
@@ -107,6 +112,12 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+<!--        This dependency was coming from Hadoop but the package has been replaced in Hadoop 3.3.6.-->
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <version>${jersey-bundle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/embeddedwebserver/pom.xml
+++ b/embeddedwebserver/pom.xml
@@ -53,6 +53,15 @@
             <artifactId>tomcat-embed-websocket</artifactId>
             <version>${tomcat.embed.version}</version>
         </dependency>
+<!--        Before upgrading Hadoop to 3.3.6, this dependency was coming from-->
+<!--        ranger-plugins-audit -> hadoop-common-->
+<!--        Now hadoop-common is using com.github.pjfanning:jersey-json-->
+<!--        which needs to be excluded to avoid conflicts.-->
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <version>${jersey-bundle.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.jdt.core.compiler</groupId>
             <artifactId>ecj</artifactId>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -230,6 +230,11 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
@@ -244,6 +249,11 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
+                <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-text</artifactId>

--- a/hdfs-agent/pom.xml
+++ b/hdfs-agent/pom.xml
@@ -42,6 +42,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                    <groupId>io.netty</groupId>
                    <artifactId>netty-transport-native-epoll</artifactId>
                 </exclusion>
@@ -63,6 +68,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
+<!--        This dependency was coming from Hadoop but the package has been replaced in Hadoop 3.3.6.-->
+<!--        This is probably not needed, because it is now accessed from 'ranger-plugins-audit'.-->
+<!--        Uncomment if an issue arises.-->
+
+<!--        <dependency>-->
+<!--            <groupId>com.sun.jersey</groupId>-->
+<!--            <artifactId>jersey-json</artifactId>-->
+<!--            <version>${jersey-bundle.version}</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
@@ -119,6 +133,11 @@
             <version>${hadoop.version}</version>
             <scope>test</scope>
             <exclusions>
+                <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -43,6 +43,12 @@
             <version>${hive.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+<!--                    hive-common has a dependency on hive-shims -> hadoop-yarn-server-resourcemanager which brings this in.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/kms/pom.xml
+++ b/kms/pom.xml
@@ -59,6 +59,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>
@@ -206,6 +211,11 @@
             <scope>test</scope>
             <type>test-jar</type>
             <exclusions>
+                <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>

--- a/plugin-schema-registry/pom.xml
+++ b/plugin-schema-registry/pom.xml
@@ -55,7 +55,8 @@
                         <artifactId>jersey-core</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>com.sun.jersey</groupId>
+<!--                        Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                        <groupId>com.github.pjfanning</groupId>
                         <artifactId>jersey-json</artifactId>
                     </exclusion>
                     <exclusion>

--- a/plugin-yarn/pom.xml
+++ b/plugin-yarn/pom.xml
@@ -52,6 +52,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -145,11 +145,12 @@
         <javax.annotation-api>1.3.2</javax.annotation-api>
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <jericho.html.version>3.3</jericho.html.version>
-        <jersey-bundle.version>1.19.3</jersey-bundle.version>
+<!--        Hadoop 3.3.6 uses jersey version 1.19.4. Upgrade to avoid unexpected behavior.-->
+        <jersey-bundle.version>1.19.4</jersey-bundle.version>
         <jersey-client.version>2.35</jersey-client.version>
-        <jersey-core.version>1.19.3</jersey-core.version>
-        <jersey-server.version>1.19.3</jersey-server.version>
-        <jersey-spring.version>1.19.3</jersey-spring.version>
+        <jersey-core.version>1.19.4</jersey-core.version>
+        <jersey-server.version>1.19.4</jersey-server.version>
+        <jersey-spring.version>1.19.4</jersey-spring.version>
         <jaxb-impl.version>2.3.3</jaxb-impl.version>
         <jettison.version>1.1</jettison.version>
         <jetty-client.version>9.4.31.v20200723</jetty-client.version>
@@ -207,8 +208,10 @@
         <zookeeper.version>3.4.14</zookeeper.version>
         <codehaus.woodstox.stax2api.version>4.2.1</codehaus.woodstox.stax2api.version>
         <fasterxml.woodstox.version>5.4.0</fasterxml.woodstox.version>
-        <fasterxml.jackson.version>2.11.3</fasterxml.jackson.version>
-        <fasterxml.jackson.databind.version>2.11.3</fasterxml.jackson.databind.version>
+<!--        Upgrade fasterxml.jackson version to use the same as Hadoop 3.3.6-->
+<!--        and avoid any unexpected behavior.-->
+        <fasterxml.jackson.version>2.12.7</fasterxml.jackson.version>
+        <fasterxml.jackson.databind.version>2.12.7.1</fasterxml.jackson.databind.version>
         <kstruct.gethostname4j.version>1.0.0</kstruct.gethostname4j.version>
         <jna.version>5.7.0</jna.version>
         <jna-platform.version>5.7.0</jna-platform.version>

--- a/ranger-examples/plugin-sampleapp/pom.xml
+++ b/ranger-examples/plugin-sampleapp/pom.xml
@@ -43,6 +43,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                    <groupId>io.netty</groupId>
                    <artifactId>netty-handler</artifactId>
                 </exclusion>

--- a/ranger-hdfs-plugin-shim/pom.xml
+++ b/ranger-hdfs-plugin-shim/pom.xml
@@ -37,6 +37,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                    <groupId>io.netty</groupId>
                    <artifactId>netty-handler</artifactId>
                 </exclusion>

--- a/ranger-hive-plugin-shim/pom.xml
+++ b/ranger-hive-plugin-shim/pom.xml
@@ -37,6 +37,12 @@
             <version>${hive.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+<!--                    hive-common has a dependency on hive-shims -> hadoop-yarn-server-resourcemanager which brings this in.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/ranger-storm-plugin-shim/pom.xml
+++ b/ranger-storm-plugin-shim/pom.xml
@@ -77,6 +77,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                    <groupId>io.netty</groupId>
                    <artifactId>netty-handler</artifactId>
                 </exclusion>

--- a/ranger-yarn-plugin-shim/pom.xml
+++ b/ranger-yarn-plugin-shim/pom.xml
@@ -52,6 +52,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -243,6 +243,12 @@
             <artifactId>jersey-bundle</artifactId>
             <version>${jersey-bundle.version}</version>
         </dependency>
+<!--        This dependency was coming from Hadoop but it has been replaced in Hadoop 3.3.6.-->
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <version>${jersey-bundle.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
@@ -293,6 +299,11 @@
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
+                <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>
                     <artifactId>jackson-jaxrs-json-provider</artifactId>
@@ -516,7 +527,8 @@
                     <artifactId>jersey-server</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.sun.jersey</groupId>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey. -->
+                    <groupId>com.github.pjfanning</groupId>
                     <artifactId>jersey-json</artifactId>
                 </exclusion>
                 <exclusion>

--- a/storm-agent/pom.xml
+++ b/storm-agent/pom.xml
@@ -113,6 +113,11 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+<!--                    Hadoop 3.3.6 uses com.github.pjfanning instead of com.sun.jersey.-->
+                    <groupId>com.github.pjfanning</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
                    <groupId>io.netty</groupId>
                    <artifactId>netty-handler</artifactId>
                 </exclusion>


### PR DESCRIPTION
Ranger used to fail during startup due to an issue with the `jersey-json` dependency.

Ranger-2.4 had a dependency on Hadoop 3.3.0 which had a dependency on `com.sun.jersey:jersey-json`. That way ranger was getting `com.sun.jersey:jersey-json` from its hadoop dependency.

In Hadoop 3.3.6, the package was replaced for the `jersey-json` dep and instead of `com.sun.jersey:jersey-json`, the dependency was now accessed from `com.github.pjfanning:jersey-json`.

By upgrading Ranger's Hadoop dependency to 3.3.6, we replaced `com.sun.jersey:jersey-json` with `com.github.pjfanning:jersey-json` but Ranger was still having a dependency on `com.sun.jersey:jersey-json` on modules where there was no hadoop dep and it had to get `jersey-json` itself.

That was the cause of the startup issue. To fix it, we need to exclude `com.github.pjfanning:jersey-json` from all hadoop dependencies and manually add it wherever the module doesn't get it from another Ranger module.

I've compared the dependency trees for the current branch and branch `ranger-2.4` and I've made sure that all the packages that used to use `jersey-json`, still have it available only once.