### PR TITLE
decrease the unnecessary calls to createMetastoreClient

### DIFF
--- a/embeddedwebserver/src/main/java/org/apache/ranger/server/tomcat/EmbeddedServer.java
+++ b/embeddedwebserver/src/main/java/org/apache/ranger/server/tomcat/EmbeddedServer.java
@@ -104,7 +104,7 @@ public class EmbeddedServer {
 
 	public void start() {
 		SSLContext sslContext = getSSLContext();
-		LOG.info("HMSA v1.1");
+		LOG.info("HMSA v1.2");
 		if (sslContext != null) {
 			SSLContext.setDefault(sslContext);
 		}

--- a/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
+++ b/unixauthservice/src/main/java/org/apache/ranger/authentication/UnixAuthenticationService.java
@@ -115,7 +115,7 @@ public class UnixAuthenticationService {
 	public void run() {
 		try {
 			LOG.info("Starting User Sync Service!");
-			LOG.info("HMSA v1.1");
+			LOG.info("HMSA v1.2");
 			startUnixUserGroupSyncProcess();
 			Thread.sleep(5000);
 			if (enableUnixAuth) {


### PR DESCRIPTION

When using the debugger in C3 I can see that the RangerHiveAuthorizer is unnecessarily creating HMS clients, which noticibly effects performance when running with kerberos.

This PR removes the unneeded creates.
